### PR TITLE
Save 20~30 minutes on every shared memory run.

### DIFF
--- a/hulc/__init__.py
+++ b/hulc/__init__.py
@@ -8,3 +8,35 @@ __project__ = "HULC"
 __author__ = "Oier Mees"
 __license__ = "MIT"
 __email__ = "meeso@informatik.uni-freiburg.de"
+
+
+
+def remove_shm_from_resource_tracker():
+    """
+    Monkey patch multiprocessing.resource_tracker so SharedMemory won't be tracked
+    More details at: https://bugs.python.org/issue38119
+    """
+    # pylint: disable=protected-access, import-outside-toplevel
+    # Ignore linting errors in this bug workaround hack
+    from multiprocessing import resource_tracker
+
+    def fix_register(name, rtype):
+        if rtype == "shared_memory":
+            return None
+        return resource_tracker._resource_tracker.register(name, rtype)
+
+    resource_tracker.register = fix_register
+
+    def fix_unregister(name, rtype):
+        if rtype == "shared_memory":
+            return None
+        return resource_tracker._resource_tracker.unregister(name, rtype)
+
+    resource_tracker.unregister = fix_unregister
+    if "shared_memory" in resource_tracker._CLEANUP_FUNCS:
+        del resource_tracker._CLEANUP_FUNCS["shared_memory"]
+
+
+# More details at: https://bugs.python.org/issue38119
+remove_shm_from_resource_tracker()
+


### PR DESCRIPTION
This addition to the code modifies the behavior of the multiprocessing.resource_tracker module in Python. It applies a monkey patch to ensure that the SharedMemory resource type is not tracked by the resource tracker.

The purpose of this modification is to prevent the training and validation language episodes from being removed from memory each time. By allowing these episodes to persist in memory, the code can save a significant amount of time, approximately 20 to 30 minutes, in each run.

The modification achieves this by overriding the register and unregister functions of the resource tracker. When a resource type is "shared_memory," these functions return None, effectively skipping the registration and unregistration process.

Additionally, the modification removes the "shared_memory" entry from the _CLEANUP_FUNCS dictionary of the resource tracker. This ensures that the cleanup function for shared memory is not called.

By making these changes, the code avoids the unnecessary overhead of reloading the training and validation language episodes, resulting in a considerable time-saving benefit during execution.